### PR TITLE
fix: camera controller disposal

### DIFF
--- a/lib/src/features/posting/providers/camera_provider.dart
+++ b/lib/src/features/posting/providers/camera_provider.dart
@@ -14,7 +14,12 @@ part 'camera_provider.g.dart';
 class Camera extends _$Camera {
   late final SparkLogger _logger;
   AppLifecycleListener? _lifecycleListener;
+  CameraController? _controller;
   bool _isFlippingCamera = false;
+
+  /// The controller is owned by this provider. Callers may borrow it for the
+  /// preview, but must not dispose it.
+  CameraController? get controller => _controller;
 
   // Track if camera was disposed due to app lifecycle (not user navigation)
   bool _wasDisposedByLifecycle = false;
@@ -23,10 +28,10 @@ class Camera extends _$Camera {
   FutureOr<CameraState> build(ResolutionPreset resolutionPreset) async {
     _logger = GetIt.instance<LogService>().getLogger('Camera');
 
-    // Only dispose lifecycle listener when provider is permanently disposed
-    // Don't use _disposeCamera here - we need to keep lifecycle listener
-    // active so we can detect when app returns to foreground
-    ref.onDispose(_disposeLifecycleListener);
+    ref.onDispose(() {
+      _disposeLifecycleListener();
+      unawaited(_disposeOwnedCamera());
+    });
 
     // Listen to app lifecycle to pause/resume camera
     // Note: onHide is for app fully backgrounded (not transient inactive states)
@@ -86,13 +91,9 @@ class Camera extends _$Camera {
 
       _logger.i('Found ${cameras.length} cameras');
 
-      final controller = await _createCameraController(cameras.first);
+      await _createCameraController(cameras.first);
 
-      return CameraState(
-        controller: controller,
-        cameras: cameras,
-        isInitialized: true,
-      );
+      return CameraState(cameras: cameras, isInitialized: true);
     } catch (e, stackTrace) {
       _logger.e(
         'Camera initialization failed',
@@ -113,15 +114,27 @@ class Camera extends _$Camera {
       resolutionPreset,
       imageFormatGroup: ImageFormatGroup.jpeg,
     );
+    _controller = controller;
 
-    await controller.initialize();
+    try {
+      await controller.initialize();
 
-    if (controller.value.isInitialized) {
-      _logger.i('Camera controller successfully initialized');
-      return controller;
-    } else {
+      if (!ref.mounted) {
+        throw StateError('Camera provider disposed during initialization');
+      }
+      if (controller.value.isInitialized) {
+        _logger.i('Camera controller successfully initialized');
+        return controller;
+      }
+
       _logger.e('Camera controller initialization incomplete');
       throw Exception('Camera controller initialized but camera not ready');
+    } catch (_) {
+      if (identical(_controller, controller)) {
+        _controller = null;
+      }
+      await controller.dispose();
+      rethrow;
     }
   }
 
@@ -168,7 +181,7 @@ class Camera extends _$Camera {
       0,
       currentState.cameras.length - 1,
     );
-    final currentCamera = currentState.controller?.description;
+    final currentCamera = _controller?.description;
     final currentLensDirection =
         currentCamera?.lensDirection ??
         currentState.cameras[fallbackIndex].lensDirection;
@@ -199,7 +212,7 @@ class Camera extends _$Camera {
 
     _logger.d('Flipping camera');
     final newCamera = currentState.cameras[newIndex];
-    final controller = currentState.controller;
+    final controller = _controller;
     _isFlippingCamera = true;
     state = AsyncValue.data(
       currentState.copyWith(isFlipping: true, error: null),
@@ -217,7 +230,6 @@ class Camera extends _$Camera {
 
         state = AsyncValue.data(
           currentState.copyWith(
-            controller: newController,
             selectedCameraIndex: newIndex,
             isInitialized: true,
             isFlipping: false,
@@ -230,7 +242,6 @@ class Camera extends _$Camera {
 
         state = AsyncValue.data(
           currentState.copyWith(
-            controller: controller,
             selectedCameraIndex: newIndex,
             isInitialized: true,
             isFlipping: false,
@@ -254,12 +265,13 @@ class Camera extends _$Camera {
 
   Future<XFile?> takePhoto() async {
     final currentState = state.value;
+    final controller = _controller;
     if (currentState == null) {
       _logger.w('Cannot take photo - no current state');
       return null;
     }
 
-    if (currentState.controller == null || !currentState.isInitialized) {
+    if (controller == null || !currentState.isInitialized) {
       _logger.w('Cannot take photo - camera not initialized');
       return null;
     }
@@ -267,7 +279,7 @@ class Camera extends _$Camera {
     _logger.d('Taking photo');
 
     try {
-      final file = await currentState.controller!.takePicture();
+      final file = await controller.takePicture();
       _logger.i('Photo taken successfully: ${file.path}');
       return file;
     } catch (e, stackTrace) {
@@ -279,12 +291,13 @@ class Camera extends _$Camera {
 
   Future<bool> startVideoRecording() async {
     final currentState = state.value;
+    final controller = _controller;
     if (currentState == null) {
       _logger.w('Cannot start recording - no current state');
       return false;
     }
 
-    if (currentState.controller == null ||
+    if (controller == null ||
         !currentState.isInitialized ||
         currentState.isRecording) {
       _logger.w(
@@ -299,10 +312,8 @@ class Camera extends _$Camera {
     state = AsyncValue.data(currentState.copyWith(isRecording: true));
 
     try {
-      await currentState.controller!.prepareForVideoRecording();
-      await currentState.controller!.startVideoRecording(
-        enablePersistentRecording: true,
-      );
+      await controller.prepareForVideoRecording();
+      await controller.startVideoRecording(enablePersistentRecording: true);
       _logger.i('Video recording started successfully');
       return true;
     } catch (e, stackTrace) {
@@ -321,12 +332,13 @@ class Camera extends _$Camera {
 
   Future<XFile?> stopVideoRecording() async {
     final currentState = state.value;
+    final controller = _controller;
     if (currentState == null) {
       _logger.w('Cannot stop recording - no current state');
       return null;
     }
 
-    if (currentState.controller == null ||
+    if (controller == null ||
         !currentState.isInitialized ||
         !currentState.isRecording) {
       _logger.w('Cannot stop recording - not currently recording');
@@ -339,7 +351,7 @@ class Camera extends _$Camera {
     state = AsyncValue.data(currentState.copyWith(isRecording: false));
 
     try {
-      final file = await currentState.controller!.stopVideoRecording();
+      final file = await controller.stopVideoRecording();
       _logger.i('Video recording stopped successfully: ${file.path}');
       return file;
     } catch (e, stackTrace) {
@@ -356,14 +368,18 @@ class Camera extends _$Camera {
   Future<void> _disposeCamera() async {
     _logger.d('Disposing camera');
 
+    if (!ref.mounted) {
+      await _disposeOwnedCamera();
+      return;
+    }
+
     try {
       final currentState = state.value;
-      final controller = currentState?.controller;
-      final wasRecording = currentState?.isRecording ?? false;
+      final controller = _controller;
+      _controller = null;
 
       state = AsyncValue.data(
         currentState?.copyWith(
-              controller: null,
               isInitialized: false,
               isRecording: false,
               isFlipping: false,
@@ -373,32 +389,47 @@ class Camera extends _$Camera {
 
       if (controller != null) {
         await _waitForPreviewDetach();
-
-        if (wasRecording) {
-          _logger.d('Stopping recording before disposal');
-          try {
-            if (controller.value.isRecordingVideo) {
-              await controller.stopVideoRecording();
-            }
-          } catch (e, stackTrace) {
-            _logger.e(
-              'Error stopping recording during disposal',
-              error: e,
-              stackTrace: stackTrace,
-            );
-          }
-        }
-
-        await controller.dispose();
-        _logger.i('Camera controller disposed successfully');
+        await _disposeController(controller);
       }
     } catch (e, stackTrace) {
       _logger.e('Error disposing camera', error: e, stackTrace: stackTrace);
     }
   }
 
-  /// Disposes the lifecycle listener. Should only be called when provider
-  /// is being permanently disposed (not for lifecycle pauses).
+  Future<void> _disposeOwnedCamera() async {
+    final controller = _controller;
+    _controller = null;
+    if (controller != null) {
+      await _disposeController(controller);
+    }
+  }
+
+  Future<void> _disposeController(CameraController controller) async {
+    if (controller.value.isRecordingVideo) {
+      _logger.d('Stopping recording before disposal');
+      try {
+        await controller.stopVideoRecording();
+      } catch (e, stackTrace) {
+        _logger.e(
+          'Error stopping recording during disposal',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+
+    try {
+      await controller.dispose();
+      _logger.i('Camera controller disposed successfully');
+    } catch (e, stackTrace) {
+      _logger.e(
+        'Error disposing camera controller',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
   void _disposeLifecycleListener() {
     _lifecycleListener?.dispose();
     _lifecycleListener = null;

--- a/lib/src/features/posting/providers/camera_state.dart
+++ b/lib/src/features/posting/providers/camera_state.dart
@@ -6,7 +6,6 @@ part 'camera_state.freezed.dart';
 @freezed
 abstract class CameraState with _$CameraState {
   const factory CameraState({
-    CameraController? controller,
     @Default([]) List<CameraDescription> cameras,
     @Default(0) int selectedCameraIndex,
     @Default(false) bool isInitialized,

--- a/lib/src/features/posting/ui/pages/recording_page.dart
+++ b/lib/src/features/posting/ui/pages/recording_page.dart
@@ -237,16 +237,15 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
     }
 
     try {
+      await ref.read(_cameraProvider.notifier).disposeCamera();
+      if (!mounted) return;
+
       await context.router.push(
         ImageReviewRoute(imageFiles: photos, storyMode: widget.storyMode),
       );
 
       if (!mounted) return;
-
-      setState(() {
-        _isProcessing = false;
-      });
-      await ref.read(_cameraProvider.notifier).reinitializeCamera();
+      await _resumeCameraAfterPhotoFlow();
     } catch (e, stackTrace) {
       _logger.e(
         'Error processing multiple photos',
@@ -254,9 +253,8 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
         stackTrace: stackTrace,
       );
       if (mounted) {
-        setState(() {
-          _isProcessing = false;
-        });
+        await _resumeCameraAfterPhotoFlow();
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
@@ -272,6 +270,9 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
     if (!mounted) return;
 
     try {
+      await ref.read(_cameraProvider.notifier).disposeCamera();
+      if (!mounted) return;
+
       // Open the story image editor
       final editedImage = await GetIt.I<ProVideoEditorRepository>()
           .openStoryImageEditor(context, photoFile);
@@ -324,20 +325,12 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
         }
       }
 
-      // Reset processing state and reinitialize camera
-      if (mounted) {
-        setState(() {
-          _isProcessing = false;
-        });
-        // Reinitialize camera after returning from editor
-        ref.read(_cameraProvider.notifier).reinitializeCamera();
-      }
+      await _resumeCameraAfterPhotoFlow();
     } catch (e, stackTrace) {
       _logger.e('Error processing photo', error: e, stackTrace: stackTrace);
       if (mounted) {
-        setState(() {
-          _isProcessing = false;
-        });
+        await _resumeCameraAfterPhotoFlow();
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
@@ -347,6 +340,15 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
         );
       }
     }
+  }
+
+  Future<void> _resumeCameraAfterPhotoFlow() async {
+    if (!mounted) return;
+
+    setState(() {
+      _isProcessing = false;
+    });
+    await ref.read(_cameraProvider.notifier).reinitializeCamera();
   }
 
   void _startRecording() {

--- a/lib/src/features/posting/ui/pages/recording_page.dart
+++ b/lib/src/features/posting/ui/pages/recording_page.dart
@@ -113,11 +113,12 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
 
   bool _isCameraReady() {
     final cameraAsync = ref.read(_cameraProvider);
+    final controller = ref.read(_cameraProvider.notifier).controller;
     if (cameraAsync.hasError) return false;
     final cameraState = cameraAsync.value;
     return cameraState != null &&
         cameraState.isInitialized &&
-        cameraState.controller != null &&
+        controller != null &&
         cameraState.cameras.isNotEmpty;
   }
 
@@ -871,6 +872,8 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
 
     return cameraAsync.when(
       data: (cameraState) {
+        final controller = ref.read(_cameraProvider.notifier).controller;
+
         if (cameraState.error != null) {
           return Scaffold(
             backgroundColor: Colors.black,
@@ -925,7 +928,7 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
         }
 
         // No cameras available - show placeholder with library picker
-        if (!hasCameras || cameraState.controller == null) {
+        if (!hasCameras || controller == null) {
           return RecordingPageTemplate(
             cameraPreview: Container(
               color: Colors.black,
@@ -975,7 +978,7 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
             availableLensDirections.contains(CameraLensDirection.back) &&
             !_isStartingRecording &&
             !cameraState.isFlipping;
-        final aspectRatio = cameraState.controller!.value.aspectRatio;
+        final aspectRatio = controller.value.aspectRatio;
         final canFinalizeSession =
             recordingState.canFinalize &&
             !_isProcessing &&
@@ -994,9 +997,7 @@ class _RecordingPageState extends ConsumerState<RecordingPage> {
             : _handleTap;
 
         return RecordingPageTemplate(
-          cameraPreview: RepaintBoundary(
-            child: CameraPreview(cameraState.controller!),
-          ),
+          cameraPreview: RepaintBoundary(child: CameraPreview(controller)),
           aspectRatio: aspectRatio,
           isRecording: recordingState.isRecording,
           elapsedDuration: recordingState.elapsedDuration,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -298,7 +298,7 @@ packages:
     source: hosted
     version: "0.10.1"
   camera_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: camera_platform_interface
       sha256: "7ac852d77699acee79f0d438b793feee26721841e50973576419ff5c6d95e9b7"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
 dev_dependencies:
   auto_route_generator: ^10.4.0
   build_runner: ^2.15.0
+  camera_platform_interface: ^2.13.0
   flutter_launcher_icons: ^0.14.4
   flutter_lints: ^6.0.0
   flutter_test:

--- a/test/src/features/posting/providers/camera_provider_test.dart
+++ b/test/src/features/posting/providers/camera_provider_test.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:camera_platform_interface/camera_platform_interface.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:spark/src/core/utils/logging/logging.dart';
+import 'package:spark/src/features/posting/providers/camera_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late CameraPlatform originalCameraPlatform;
+  late _FakeCameraPlatform cameraPlatform;
+
+  setUpAll(() {
+    originalCameraPlatform = CameraPlatform.instance;
+  });
+
+  setUp(() async {
+    await GetIt.I.reset();
+    GetIt.I.registerSingleton<LogService>(LogService());
+    cameraPlatform = _FakeCameraPlatform();
+    CameraPlatform.instance = cameraPlatform;
+  });
+
+  tearDown(() async {
+    CameraPlatform.instance = originalCameraPlatform;
+    await GetIt.I.reset();
+  });
+
+  test('auto-dispose releases the initialized camera', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final provider = cameraProvider(ResolutionPreset.low);
+    final subscription = container.listen(provider, (previous, next) {});
+
+    await container.read(provider.future);
+    expect(container.read(provider.notifier).controller, isNotNull);
+
+    subscription.close();
+    await container.pump();
+    await cameraPlatform.disposed;
+
+    expect(cameraPlatform.disposedCameraIds, [_FakeCameraPlatform.cameraId]);
+  });
+}
+
+class _FakeCameraPlatform extends CameraPlatform {
+  static const cameraId = 13;
+  static const camera = CameraDescription(
+    name: 'back',
+    lensDirection: CameraLensDirection.back,
+    sensorOrientation: 90,
+  );
+
+  final Completer<void> _disposed = Completer<void>();
+  final List<int> disposedCameraIds = [];
+
+  Future<void> get disposed => _disposed.future;
+
+  @override
+  Future<List<CameraDescription>> availableCameras() async => [camera];
+
+  @override
+  Future<int> createCameraWithSettings(
+    CameraDescription cameraDescription,
+    MediaSettings mediaSettings,
+  ) async => cameraId;
+
+  @override
+  Future<void> initializeCamera(
+    int cameraId, {
+    ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,
+  }) async {}
+
+  @override
+  Stream<CameraInitializedEvent> onCameraInitialized(int cameraId) {
+    return Stream.value(
+      CameraInitializedEvent(
+        cameraId,
+        1080,
+        1920,
+        ExposureMode.auto,
+        true,
+        FocusMode.auto,
+        true,
+      ),
+    );
+  }
+
+  @override
+  Stream<CameraErrorEvent> onCameraError(int cameraId) {
+    return Stream.value(CameraErrorEvent(cameraId, 'test error'));
+  }
+
+  @override
+  Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() {
+    return Stream.value(
+      const DeviceOrientationChangedEvent(DeviceOrientation.portraitUp),
+    );
+  }
+
+  @override
+  Future<void> dispose(int cameraId) async {
+    disposedCameraIds.add(cameraId);
+    if (!_disposed.isCompleted) {
+      _disposed.complete();
+    }
+  }
+}


### PR DESCRIPTION
Closes #126

## Summary

- Move camera controller ownership out of `CameraState` and into the provider
- Dispose controllers safely during provider teardown and lifecycle transitions
- Update recording UI access and add auto-dispose coverage
- Add the camera platform interface as a direct test dependency

## Testing

- Added a unit test verifying auto-dispose releases the initialized camera